### PR TITLE
Change to the the GithubAction and .gitignore

### DIFF
--- a/.github/workflows/docker_build_and_release.yml
+++ b/.github/workflows/docker_build_and_release.yml
@@ -46,8 +46,8 @@ jobs:
           tag_name: ${{ env.BRANCH_NAME }}-${{ env.VERSION }}-${{ env.COMMIT_HASH }}
           release_name: Release ${{ env.BRANCH_NAME }}-${{ env.VERSION }}-${{ env.COMMIT_HASH }}
           body: |
-            Changes in this Release
-            - Add your changes here
+            This is an automated pre-release of ${{ env.BRANCH_NAME }}-${{ env.VERSION }}-${{ env.COMMIT_HASH }} to see what are the changes in this release please check the commit history.
+          prerelease: true
     - name: Upload Linux Wallet
       id: upload-docker-build-output-wallet
       uses: actions/upload-release-asset@v1
@@ -102,7 +102,7 @@ jobs:
         asset_path: ./build/windows/wart-node.exe
         asset_name: wart-node-windows.exe
         asset_content_type: application/octet-stream
-        
+
     - name: Upload Windows Wallet
       id: upload-docker-build-output-wallet-windows
       uses: actions/upload-release-asset@v1

--- a/.github/workflows/docker_build_and_release.yml
+++ b/.github/workflows/docker_build_and_release.yml
@@ -16,9 +16,20 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 
-    - name: Extract branch name
-      shell: bash
-      run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//-/g')-$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
+    - name: Get branch name
+      id: get_branch_name
+      run: |
+        echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
+    
+    - name: Get version
+      id: get_version
+      run: |
+        echo "VERSION=$(grep 'version :' meson.build | cut -d "'" -f 2)" >> $GITHUB_ENV
+
+    - name: Get commit hash
+      id: get_commit_hash
+      run: |
+        echo "COMMIT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
     - name: Docker Build
       run: DOCKER_BUILDKIT=1 docker build . --output build
@@ -32,8 +43,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:
-          tag_name: ${{ env.BRANCH_NAME }}
-          release_name: Release ${{ env.BRANCH_NAME }}
+          tag_name: ${{ env.BRANCH_NAME }}-${{ env.VERSION }}-${{ env.COMMIT_HASH }}
+          release_name: Release ${{ env.BRANCH_NAME }}-${{ env.VERSION }}-${{ env.COMMIT_HASH }}
           body: |
             Changes in this Release
             - Add your changes here
@@ -47,6 +58,7 @@ jobs:
         asset_path: ./build/wart-wallet
         asset_name: wart-wallet-linux
         asset_content_type: application/octet-stream
+
     - name: Uploead Linux Node
       id: upload-docker-build-output-node
       uses: actions/upload-release-asset@v1
@@ -57,6 +69,7 @@ jobs:
         asset_path: ./build/wart-node
         asset_name: wart-node-linux
         asset_content_type: application/octet-stream
+
     - name: Upload Linux Miner
       id: upload-docker-build-output-MINER
       uses: actions/upload-release-asset@v1
@@ -67,6 +80,7 @@ jobs:
         asset_path: ./build/wart-miner
         asset_name: wart-miner-linux
         asset_content_type: application/octet-stream
+
     - name: Upload Windows Miner
       id: upload-docker-build-output-MINER-windows
       uses: actions/upload-release-asset@v1
@@ -77,6 +91,7 @@ jobs:
         asset_path: ./build/windows/wart-miner.exe
         asset_name: wart-miner-windows.exe
         asset_content_type: application/octet-stream
+
     - name: Upload Windows Node
       id: upload-docker-build-output-node-windows
       uses: actions/upload-release-asset@v1
@@ -87,6 +102,7 @@ jobs:
         asset_path: ./build/windows/wart-node.exe
         asset_name: wart-node-windows.exe
         asset_content_type: application/octet-stream
+        
     - name: Upload Windows Wallet
       id: upload-docker-build-output-wallet-windows
       uses: actions/upload-release-asset@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 compile_commands.json
 .cache
 .ccls-cache
+build/


### PR DESCRIPTION
It's now prerelease by default, looks better because we see the version of the node, and the hash of the commit. I also add /build to .gitignore.